### PR TITLE
RSS Article create-async, bugfixes

### DIFF
--- a/hudai/resources/article_key_term.py
+++ b/hudai/resources/article_key_term.py
@@ -16,27 +16,13 @@ class ArticleKeyTermResource(Resource):
     def create(self, params):
         return self.request({
             'method': 'POST',
-            'data': pick(params, 'term'),
+            'data': pick(params, 'article_id', 'term', 'published_at'),
             'url': '/internal'
         })
 
-    def get(self, id):
-        return self.request({
-            'params': {'id': id},
-            'url': '/internal/{id}'
-        })
-
-    def update(self, params):
-        return self.request({
-            'method': 'PUT',
-            'params': pick(params, 'id'),
-            'data': pick(params, 'term'),
-            'url': '/internal/{id}'
-        })
-
-    def delete(self, id):
+    def delete(self, article_id, term):
         return self.request({
             'method': 'DELETE',
-            'params': {'id': id},
-            'url': '/internal/{id}'
+            'params': { 'article_id' : article_id, 'term' : term },
+            'url': '/internal/{article_id}/{term}'
         })

--- a/hudai/resources/rss_article.py
+++ b/hudai/resources/rss_article.py
@@ -17,7 +17,7 @@ class RssArticleResource(Resource):
     def list(self, params):
         return self.request({
             'method': 'GET',
-            'params': pick(params, 'feed_url', 'feed_uuid', 'published_at'),
+            'params': pick(params, 'feed_url', 'published_before', 'published_after'),
             'url': '/internal'
         })
 
@@ -26,6 +26,13 @@ class RssArticleResource(Resource):
             'method': 'POST',
             'data': pick(params, 'data', 'feed_url', 'feed_uuid', 'published_at'),
             'url': '/internal'
+        })
+
+    def create_async(self, params):
+        return self.request({
+            'method': 'POST',
+            'data': pick(params, 'data', 'feed_url', 'feed_uuid', 'published_at'),
+            'url': '/internal/async'
         })
 
     def update(self, params):


### PR DESCRIPTION
- adds access to `POST /rss-articles/internal/async` for to enqueue insertions in bulk
- `article-key-term` schema updates, removes non-existent methods