### PR TITLE
Pluralize Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ client = HudAi(api_key='your-api-token-here')
 # Alternatively, if you're working with a non-production environment
 # client = HudAi(api_key='your-api-token-here', base_url='https://stage.api.hud.ai')
 
-client.company.list()
+client.companies.list()
 
-client.article.fetch('17787d76-4198-4775-a49a-b3581c37a482')
+client.articles.fetch('17787d76-4198-4775-a49a-b3581c37a482')
 ```
 
 ***DOCUMENTATION NOTES***
@@ -55,29 +55,29 @@ client.article.fetch('17787d76-4198-4775-a49a-b3581c37a482')
 | **`title`**        | **String**      | Title article was published as |
 | **`article_type`** | **String**      | `rss` \| `newsApi` \| `facebook` \| `twitter` |
 
-#### `client.article.list(article_type?, importance_score_min?, key_term?, link_hash?, page?, published_after?, published_before?)`
+#### `client.articles.list(article_type?, importance_score_min?, key_term?, link_hash?, page?, published_after?, published_before?)`
 
 Example:
 
 ```python
 last_week = datetime.datetime.now() - datetime.timedelta(days=7)
 
-client.article.list(article_type='rss', published_after=last_week)
+client.articles.list(article_type='rss', published_after=last_week)
 ```
 
-#### `client.article.create(**params)`
+#### `client.articles.create(**params)`
 
 Takes all of the model attributes as keyword params (except `link_hash`)
 
-#### `client.article.fetch(id)`
+#### `client.articles.fetch(id)`
 
-#### `client.article.update(id, **params)`
+#### `client.articles.update(id, **params)`
 
 Takes all of the model attributes as keyword params (except `link_hash`)
 
-#### `client.article.delete(id)`
+#### `client.articles.delete(id)`
 
-#### `client.article.key_terms(id)`
+#### `client.articles.key_terms(id)`
 
 Returns a list of key terms (`String`) associated with the article
 
@@ -116,13 +116,13 @@ Takes all of the model attributes as keyword params
 | **`article_id`** | **String** | Article identifier |
 | **`term`**       | **String** | Key term in article |
 
-#### `client.article_key_term.list(article_id, page?)`
+#### `client.article_key_terms.list(article_id, page?)`
 
-#### `client.article_key_term.create(article_id, term)`
+#### `client.article_key_terms.create(article_id, term)`
 
-#### `client.article_key_term.fetch(article_id, term)`
+#### `client.article_key_terms.fetch(article_id, term)`
 
-#### `client.article_key_term.delete(article_id, term)`
+#### `client.article_key_terms.delete(article_id, term)`
 
 
 ### Company
@@ -132,25 +132,25 @@ Takes all of the model attributes as keyword params
 | `id`       | String     | Resource ID **Cannot be edited** |
 | **`name`** | **String** | Primary company name (others can be associated as key terms) |
 
-#### `client.company.list(page?)`
+#### `client.companies.list(page?)`
 
-#### `client.company.create(**params)`
-
-Takes all of the model attributes as keyword params
-
-#### `client.company.fetch(id)`
-
-#### `client.company.update(id, **params)`
+#### `client.companies.create(**params)`
 
 Takes all of the model attributes as keyword params
 
-#### `client.company.delete(id)`
+#### `client.companies.fetch(id)`
 
-#### `client.company.domains(id)`
+#### `client.companies.update(id, **params)`
+
+Takes all of the model attributes as keyword params
+
+#### `client.companies.delete(id)`
+
+#### `client.companies.domains(id)`
 
 Lists all `Domain`s (hostnames) associated with the company
 
-#### `client.company.key_terms(id)`
+#### `client.companies.key_terms(id)`
 
 Lists all `KeyTerm`s associated with the company
 
@@ -163,15 +163,15 @@ Lists all `KeyTerm`s associated with the company
 | **`company_id`** | **String** | Associated company |
 | **`term`**       | **String** | Term (can be word or phrase) to find in articles |
 
-#### `client.company_key_term.list(company_id?, page?)`
+#### `client.company_key_terms.list(company_id?, page?)`
 
-#### `client.company_key_term.create(**params)`
+#### `client.company_key_terms.create(**params)`
 
 Takes all of the model attributes as keyword params
 
-#### `client.company_key_term.fetch(id)`
+#### `client.company_key_terms.fetch(id)`
 
-#### `client.company_key_term.delete(id)`
+#### `client.company_key_terms.delete(id)`
 
 
 ### Domain
@@ -182,19 +182,19 @@ Takes all of the model attributes as keyword params
 | **`company_id`** | **String** | Associated company |
 | **`hostname`**   | **String** | FQDN e.g. `api.hud.ai` |
 
-#### `client.domain.list(company_id?, hostname?, page?)`
+#### `client.domains.list(company_id?, hostname?, page?)`
 
-#### `client.domain.create(**params)`
-
-Takes all of the model attributes as keyword params
-
-#### `client.domain.fetch(id)`
-
-#### `client.domain.update(id, **params)`
+#### `client.domains.create(**params)`
 
 Takes all of the model attributes as keyword params
 
-#### `client.domain.delete(id)`
+#### `client.domains.fetch(id)`
+
+#### `client.domains.update(id, **params)`
+
+Takes all of the model attributes as keyword params
+
+#### `client.domains.delete(id)`
 
 
 ### KeyTerm
@@ -203,18 +203,18 @@ Takes all of the model attributes as keyword params
 | --------- | ---- | ----------- |
 | **`term`** | **String** | Term (can be word or phrase) to find in articles |
 
-#### `client.key_term.list(page?)`
+#### `client.key_terms.list(page?)`
 
-#### `client.key_term.create(**params)`
+#### `client.key_terms.create(**params)`
 
 Takes all of the model attributes as keyword params
 
-#### `client.key_term.fetch(term)`
+#### `client.key_terms.fetch(term)`
 
-#### `client.key_term.delete(term)`
+#### `client.key_terms.delete(term)`
 
 
-### RelevantArticles
+### RelevantArticle
 
 | Attribute | Type | Description |
 | --------- | ---- | ----------- |
@@ -251,13 +251,13 @@ Only the `score` and `scored_at` and `article_published_at` can be updated.
 | **`name`**    | **String**     | Event identifier e.g. `article.processed` |
 | **`payload`** | **Dictionary** | Event payload e.g. `{'location': 's3://my-bucket/file-path', type:'rss'}` |
 
-#### `client.system_event.list(page?)`
+#### `client.system_events.list(page?)`
 
-#### `client.system_event.create(**params)`
+#### `client.system_events.create(**params)`
 
 Takes all of the model attributes as keyword params
 
-#### `client.system_event.fetch(id)`
+#### `client.system_events.fetch(id)`
 
 
 ### SystemTask
@@ -270,25 +270,25 @@ Takes all of the model attributes as keyword params
 | `completed_at` | Date       | When the job finished (irregardless of success) |
 | `started_at`   | Date       | Last time that the job was attempted |
 
-#### `client.system_task.list(completed?, started_after?, started_before?, task_id?, page?)`
+#### `client.system_tasks.list(completed?, started_after?, started_before?, task_id?, page?)`
 
-#### `client.system_task.create(**params)`
-
-Takes all of the model attributes as keyword params
-
-#### `client.system_task.fetch(id)`
-
-#### `client.system_task.fetch_by_task_id(task_id)`
-
-#### `client.system_task.update(id, **params)`
+#### `client.system_tasks.create(**params)`
 
 Takes all of the model attributes as keyword params
 
-#### `client.system_task.mark_complete(id, completed_at?)`
+#### `client.system_tasks.fetch(id)`
+
+#### `client.system_tasks.fetch_by_task_id(task_id)`
+
+#### `client.system_tasks.update(id, **params)`
+
+Takes all of the model attributes as keyword params
+
+#### `client.system_tasks.mark_complete(id, completed_at?)`
 
 When `completed_at` is omitted, it will default to now.
 
-#### `client.system_task.delete(id)`
+#### `client.system_tasks.delete(id)`
 
 
 ### TextCorpus
@@ -300,19 +300,19 @@ When `completed_at` is omitted, it will default to now.
 | **`type`**     | **String** | Text origin e.g. `email` or `custom` |
 | **`user_id`**  | **String** | User the corpus is used to identify articles for |
 
-#### `client.text_corpus.list(type?, user_id?, page?)`
+#### `client.text_corpora.list(type?, user_id?, page?)`
 
-#### `client.text_corpus.create(**params)`
-
-Takes all of the model attributes as keyword params
-
-#### `client.text_corpus.fetch(id)`
-
-#### `client.text_corpus.update(id, **params)`
+#### `client.text_corpora.create(**params)`
 
 Takes all of the model attributes as keyword params
 
-#### `client.text_corpus.delete(id)`
+#### `client.text_corpora.fetch(id)`
+
+#### `client.text_corpora.update(id, **params)`
+
+Takes all of the model attributes as keyword params
+
+#### `client.text_corpora.delete(id)`
 
 
 ### User
@@ -324,19 +324,19 @@ Takes all of the model attributes as keyword params
 | **`name`**  | **String** | User's full name (used in emails and other communications) |
 | `time_zone` | String     | [tz database][tz-database-link] time zone used to determine when to send notifications (defaults to `America/New_York`) |
 
-#### `client.user.list(email?, digest_subscription_day?, digest_subscription_hour?, name?, key_term?, page?)`
+#### `client.users.list(email?, digest_subscription_day?, digest_subscription_hour?, name?, key_term?, page?)`
 
-#### `client.user.create(**params)`
-
-Takes all of the model attributes as keyword params
-
-#### `client.user.fetch(id)`
-
-#### `client.user.update(id, **params)`
+#### `client.users.create(**params)`
 
 Takes all of the model attributes as keyword params
 
-#### `client.user.delete(id)`
+#### `client.users.fetch(id)`
+
+#### `client.users.update(id, **params)`
+
+Takes all of the model attributes as keyword params
+
+#### `client.users.delete(id)`
 
 
 ### UserCompany
@@ -347,15 +347,15 @@ Takes all of the model attributes as keyword params
 | **`company_id`** | **String** | Associated company |
 | **`user_id`**    | **String** | Associated user |
 
-#### `client.user_company.list(company_id?, user_id?, page?)`
+#### `client.user_companies.list(company_id?, user_id?, page?)`
 
-#### `client.user_company.create(**params)`
+#### `client.user_companies.create(**params)`
 
 Takes all of the model attributes as keyword params
 
-#### `client.user_company.fetch(id)`
+#### `client.user_companies.fetch(id)`
 
-#### `client.user_company.delete(id)`
+#### `client.user_companies.delete(id)`
 
 
 ### UserDigestSubscription
@@ -367,15 +367,15 @@ Takes all of the model attributes as keyword params
 | **`iso_hour`**    | **String** | 24-hour hour e.g. `08` = 8am, `17` = 5pm |
 | **`user_id`**     | **String** | Associated user |
 
-#### `client.user_digest_subscription.list(user_id, day_of_week?, iso_hour?, page?)`
+#### `client.user_digest_subscriptions.list(user_id, day_of_week?, iso_hour?, page?)`
 
-#### `client.user_digest_subscription.create(user_id, **params)`
+#### `client.user_digest_subscriptions.create(user_id, **params)`
 
 Takes all of the model attributes as keyword params
 
-#### `client.user_digest_subscription.fetch(user_id, digest_id)`
+#### `client.user_digest_subscriptions.fetch(user_id, digest_id)`
 
-#### `client.user_digest_subscription.delete(user_id, digest_id)`
+#### `client.user_digest_subscriptions.delete(user_id, digest_id)`
 
 
 ### UserKeyTerm
@@ -386,13 +386,13 @@ Takes all of the model attributes as keyword params
 | **`term`**    | **String** | Term (can be word or phrase) to find in articles |
 | **`user_id`** | **String** | Associated user |
 
-#### `client.user_key_term.list(user_id, page?)`
+#### `client.user_key_terms.list(user_id, page?)`
 
-#### `client.user_key_term.create(user_id, term)`
+#### `client.user_key_terms.create(user_id, term)`
 
-#### `client.user_key_term.fetch(user_id, term)`
+#### `client.user_key_terms.fetch(user_id, term)`
 
-#### `client.user_key_term.delete(user_id, term)`
+#### `client.user_key_terms.delete(user_id, term)`
 
 
 ## Deployment

--- a/hudai/client.py
+++ b/hudai/client.py
@@ -23,33 +23,23 @@ class HudAi(object):
         self._base_url = base_url
 
         self.article_highlights = ArticleHighlightsResource(self)
-        self.article_highlight = self.article_highlights
-        self.article_key_term = ArticleKeyTermResource(self)
-        self.article_key_terms = self.article_key_term
-        self.article = ArticleResource(self)
-        self.articles = self.article
-        self.company_key_term = CompanyKeyTermResource(self)
-        self.company_key_terms = self.company_key_term
-        self.company = CompanyResource(self)
-        self.companies = self.company
-        self.domain = DomainResource(self)
-        self.domains = self.domain
-        self.key_term = KeyTermResource(self)
-        self.key_terms = self.key_term
-        self.system_event = SystemEventResource(self)
-        self.system_events = self.system_event
-        self.system_task = SystemTaskResource(self)
-        self.system_tasks = self.system_task
-        self.text_corpus = TextCorpusResource(self)
-        self.text_corpora = self.text_corpus
-        self.user_company = UserCompanyResource(self)
-        self.user_companies = self.user_company
-        self.user_digest_subscription = UserDigestSubscriptionResource(self)
-        self.user_digest_subscriptions = self.user_digest_subscription
-        self.user_key_term = UserKeyTermResource(self)
-        self.user_key_terms = self.user_key_term
-        self.user = UserResource(self)
-        self.users = self.user
+        self.article_key_terms = ArticleKeyTermResource(self)
+        self.articles = ArticleResource(self)
+        self.company_key_terms = CompanyKeyTermResource(self)
+        self.companies = CompanyResource(self)
+        self.domains = DomainResource(self)
+        self.key_terms = KeyTermResource(self)
+        self.relevant_articles = RelevantArticlesResource(self)
+        self.system_events = SystemEventResource(self)
+        self.system_tasks = SystemTaskResource(self)
+        self.text_corpora = TextCorpusResource(self)
+        self.user_companies = UserCompanyResource(self)
+        self.user_digest_subscriptions = UserDigestSubscriptionResource(self)
+        self.user_key_terms = UserKeyTermResource(self)
+        self.users = UserResource(self)
+
+        # Preserve backwards compatibility
+        self._add_deprecated_attributes()
 
 
     def http_get(self, path, query_params={}):
@@ -122,6 +112,24 @@ class HudAi(object):
                                    headers=self._get_headers())
 
         return self._pythonify(response.json())
+
+
+    def _add_deprecated_attributes(self):
+        self.article_highlight = self.article_highlights
+        self.article_key_term = self.article_key_terms
+        self.article = self.articles
+        self.company_key_term = self.company_key_terms
+        self.company = self.companies
+        self.domain = self.domains
+        self.key_term = self.key_terms
+        self.relevant_article = self.relevant_articles
+        self.system_event = self.system_events
+        self.system_task = self.system_tasks
+        self.text_corpus = self.text_corpora
+        self.user_company = self.user_companies
+        self.user_digest_subscription = self.user_digest_subscriptions
+        self.user_key_term = self.user_key_terms
+        self.user = self.users
 
 
     def _build_url(self, path):

--- a/hudai/resources/__init__.py
+++ b/hudai/resources/__init__.py
@@ -5,6 +5,7 @@ from .company_key_term import CompanyKeyTermResource
 from .company import CompanyResource
 from .domain import DomainResource
 from .key_term import KeyTermResource
+from .relevant_articles import RelevantArticlesResource
 from .system_event import SystemEventResource
 from .system_task import SystemTaskResource
 from .text_corpus import TextCorpusResource

--- a/hudai/resources/system_task.py
+++ b/hudai/resources/system_task.py
@@ -28,12 +28,17 @@ class SystemTaskResource(Resource):
             started_before=started_before,
             completed=completed)
 
-    def create(self, task_id=None, started_at=None, completed_at=None):
+    def create(self,
+               task_id=None,
+               attempts=None,
+               started_at=None,
+               completed_at=None):
         """
         Creates a new system task
         """
         return self._create(
             task_id=task_id,
+            attempts=attempts,
             started_at=started_at,
             completed_at=completed_at)
 
@@ -50,11 +55,16 @@ class SystemTaskResource(Resource):
         tasks = self._list(task_id=task_id).get('rows', [])
         return tasks[0] if tasks else api_404()
 
-    def update(self, entity_id, started_at=None, completed_at=None):
+    def update(self,
+               entity_id,
+               attempts=None,
+               started_at=None,
+               completed_at=None):
         """
         Update the task's started_at or completed_at
         """
         return self._update(entity_id,
+                            attempts=attempts,
                             started_at=started_at,
                             completed_at=completed_at)
 


### PR DESCRIPTION
Makes plural form of resource (e.g. `client.companies` or `client.users`) the primary accessor, maintains old names as deprecated

Adds `attempts` to `SystemTask` creation/updates

Adds `client.relevant_articles`